### PR TITLE
Fixed panic on space seperated input

### DIFF
--- a/iitk_traveller/Cargo.toml
+++ b/iitk_traveller/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+text_io = "0.1.12"

--- a/iitk_traveller/src/traveller.rs
+++ b/iitk_traveller/src/traveller.rs
@@ -1,6 +1,4 @@
-// use core::panic;
 use std::collections::HashMap;
-// use std::io::{self};
 use text_io::read;
 
 pub struct TravelStat {
@@ -43,32 +41,13 @@ impl TravelStat {
         mem: &mut Vec<Vec<i32>>,
         loc: &HashMap<String, i32>,
     ) {
-        // let mut inp = "".to_string();
 
         match operation {
             2 => {
-                // "iit_gate_in_1"
-                // io::stdin()
-                //     .read_line(&mut inp)
-                //     .expect("Failed to read line");
-                // mem[self.mem1_lvl][self.mem1] = match inp.trim().parse() {
-                //     Ok(num) => num,
-                //     Err(_) => panic!("Invalid Input!"),
-                // };
-
                 let i: i32 = read!();
                 mem[self.mem1_lvl][self.mem1] = i;
             }
             3 => {
-                // "iit_gate_in_2"
-                // io::stdin()
-                //     .read_line(&mut inp)
-                //     .expect("Failed to read line");
-                // mem[self.mem2_lvl][self.mem2] = match inp.trim().parse() {
-                //     Ok(num) => num,
-                //     Err(_) => panic!("Invalid Input!"),
-                // };
-
                 let i:i32 = read!();
                 mem[self.mem2_lvl][self.mem2] = i;
             }

--- a/iitk_traveller/src/traveller.rs
+++ b/iitk_traveller/src/traveller.rs
@@ -1,6 +1,7 @@
 // use core::panic;
 use std::collections::HashMap;
-use std::io::{self};
+// use std::io::{self};
+use text_io::read;
 
 pub struct TravelStat {
     mem1: usize,
@@ -42,28 +43,34 @@ impl TravelStat {
         mem: &mut Vec<Vec<i32>>,
         loc: &HashMap<String, i32>,
     ) {
-        let mut inp = "".to_string();
+        // let mut inp = "".to_string();
 
         match operation {
             2 => {
                 // "iit_gate_in_1"
-                io::stdin()
-                    .read_line(&mut inp)
-                    .expect("Failed to read line");
-                mem[self.mem1_lvl][self.mem1] = match inp.trim().parse() {
-                    Ok(num) => num,
-                    Err(_) => panic!("Invalid Input!"),
-                };
+                // io::stdin()
+                //     .read_line(&mut inp)
+                //     .expect("Failed to read line");
+                // mem[self.mem1_lvl][self.mem1] = match inp.trim().parse() {
+                //     Ok(num) => num,
+                //     Err(_) => panic!("Invalid Input!"),
+                // };
+
+                let i: i32 = read!();
+                mem[self.mem1_lvl][self.mem1] = i;
             }
             3 => {
                 // "iit_gate_in_2"
-                io::stdin()
-                    .read_line(&mut inp)
-                    .expect("Failed to read line");
-                mem[self.mem2_lvl][self.mem2] = match inp.trim().parse() {
-                    Ok(num) => num,
-                    Err(_) => panic!("Invalid Input!"),
-                };
+                // io::stdin()
+                //     .read_line(&mut inp)
+                //     .expect("Failed to read line");
+                // mem[self.mem2_lvl][self.mem2] = match inp.trim().parse() {
+                //     Ok(num) => num,
+                //     Err(_) => panic!("Invalid Input!"),
+                // };
+
+                let i:i32 = read!();
+                mem[self.mem2_lvl][self.mem2] = i;
             }
             4 => {
                 mem[self.mem3_lvl][self.mem3] = mem[self.mem1_lvl][self.mem1]


### PR DESCRIPTION
Interpreter would panic on space seperated input, fixed using the read! macro